### PR TITLE
Ums device id x3

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -61,6 +61,16 @@ int switchtec_handler(const char *optarg, void *value_addr,
 		return 1;
 	}
 
+	if (switchtec_is_gen3(dev) && switchtec_is_pax(dev)) {
+		fprintf(stderr, "%s: Gen3 PAX is not supported.\n", optarg);
+		return 2;
+	}
+
+	if (switchtec_is_gen4(dev)) {
+		fprintf(stderr, "%s: Gen4 is not supported.\n", optarg);
+		return 3;
+	}
+
 	*((struct switchtec_dev  **) value_addr) = dev;
 	return 0;
 }

--- a/cli/main.c
+++ b/cli/main.c
@@ -112,6 +112,46 @@ static int list(int argc, char **argv)
 	return 0;
 }
 
+int print_dev_info(struct switchtec_dev *dev)
+{
+	int ret;
+	int device_id;
+	char version[64];
+
+	device_id = switchtec_device_id(dev);
+
+	ret = switchtec_get_fw_version(dev, version, sizeof(version));
+	if (ret < 0) {
+		switchtec_perror("dev info");
+		return ret;
+	}
+
+	printf("%s:\n", switchtec_name(dev));
+	printf("    Generation:  %s\n", switchtec_gen_str(dev));
+	printf("    Variant:     %s\n", switchtec_variant_str(dev));
+	printf("    Device ID:   0x%04x\n", device_id);
+	printf("    FW Version:  %s\n", version);
+
+	return 0;
+}
+
+static int info(int argc, char **argv)
+{
+	const char *desc = "Display information for a Switchtec device";
+
+	static struct {
+		struct switchtec_dev *dev;
+	} cfg = {};
+
+	const struct argconfig_options opts[] = {
+		DEVICE_OPTION,
+		{NULL}};
+
+	argconfig_parse(argc, argv, desc, opts, &cfg, sizeof(cfg));
+
+	return print_dev_info(cfg.dev);
+}
+
 static void print_port_title(struct switchtec_dev *dev,
 			     struct switchtec_port_id *p)
 {
@@ -2001,6 +2041,7 @@ static int evcntr_wait(int argc, char **argv)
 
 static const struct cmd commands[] = {
 	CMD(list, "List all switchtec devices on this machine"),
+	CMD(info, "Display information for a Switchtec device"),
 	CMD(gui, "Display a simple ncurses GUI for the switch"),
 	CMD(status, "Display status information"),
 	CMD(bw, "Measure the bandwidth for each port"),

--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -73,6 +73,27 @@ typedef __gas struct switchtec_gas *gasptr_t;
 #define SWITCHTEC_MAP_FAILED ((gasptr_t) -1)
 
 /**
+ * @brief The PCIe generations
+ */
+enum switchtec_gen {
+	SWITCHTEC_GEN3,
+	SWITCHTEC_GEN4,
+	SWITCHTEC_GEN_UNKNOWN,
+};
+
+/**
+ * @brief The variant types of Switchtec device
+ */
+enum switchtec_variant {
+	SWITCHTEC_PFX,
+	SWITCHTEC_PFXL,
+	SWITCHTEC_PFXI,
+	SWITCHTEC_PSX,
+	SWITCHTEC_PAX,
+	SWITCHTEC_VAR_UNKNOWN,
+};
+
+/**
  * @brief Represents a Switchtec device in the switchtec_list() function
  */
 struct switchtec_device_info {
@@ -275,6 +296,9 @@ int switchtec_event_wait(struct switchtec_dev *dev, int timeout_ms);
 
 _PURE const char *switchtec_name(struct switchtec_dev *dev);
 _PURE int switchtec_partition(struct switchtec_dev *dev);
+_PURE int switchtec_device_id(struct switchtec_dev *dev);
+_PURE enum switchtec_gen switchtec_gen(struct switchtec_dev *dev);
+_PURE enum switchtec_variant switchtec_variant(struct switchtec_dev *dev);
 int switchtec_echo(struct switchtec_dev *dev, uint32_t input, uint32_t *output);
 int switchtec_hard_reset(struct switchtec_dev *dev);
 int switchtec_status(struct switchtec_dev *dev,
@@ -287,6 +311,80 @@ int switchtec_log_to_file(struct switchtec_dev *dev,
 			  enum switchtec_log_type type,
 			  int fd);
 float switchtec_die_temp(struct switchtec_dev *dev);
+
+/**
+ * @brief Return whether a Switchtec device is a Gen 3 device.
+ */
+static inline int switchtec_is_gen3(struct switchtec_dev *dev)
+{
+	return switchtec_gen(dev) == SWITCHTEC_GEN3;
+}
+
+/**
+ * @brief Return whether a Switchtec device is a Gen 4 device.
+ */
+static inline int switchtec_is_gen4(struct switchtec_dev *dev)
+{
+	return switchtec_gen(dev) == SWITCHTEC_GEN4;
+}
+
+/**
+ * @brief Return whether a Switchtec device is PFX.
+ */
+static inline int switchtec_is_pfx(struct switchtec_dev *dev)
+{
+	return switchtec_variant(dev) == SWITCHTEC_PFX;
+}
+
+/**
+ * @brief Return whether a Switchtec device is PFX-L.
+ */
+static inline int switchtec_is_pfxl(struct switchtec_dev *dev)
+{
+	return switchtec_variant(dev) == SWITCHTEC_PFXL;
+}
+
+/**
+ * @brief Return whether a Switchtec device is PFX-I.
+ */
+static inline int switchtec_is_pfxi(struct switchtec_dev *dev)
+{
+	return switchtec_variant(dev) == SWITCHTEC_PFXI;
+}
+
+/**
+ * @brief Return whether a Switchtec device is PFX(L/I).
+ */
+static inline int switchtec_is_pfx_all(struct switchtec_dev *dev)
+{
+	return switchtec_is_pfx(dev) ||
+	       switchtec_is_pfxl(dev) ||
+	       switchtec_is_pfxi(dev);
+}
+
+/**
+ * @brief Return whether a Switchtec device is PSX.
+ */
+static inline int switchtec_is_psx(struct switchtec_dev *dev)
+{
+	return switchtec_variant(dev) == SWITCHTEC_PSX;
+}
+
+/**
+ * @brief Return whether a Switchtec device is PFX or PSX.
+ */
+static inline int switchtec_is_psx_pfx_all(struct switchtec_dev *dev)
+{
+	return switchtec_is_psx(dev) || switchtec_is_pfx_all(dev);
+}
+
+/**
+ * @brief Return whether a Switchtec device is PAX.
+ */
+static inline int switchtec_is_pax(struct switchtec_dev *dev)
+{
+	return switchtec_variant(dev) == SWITCHTEC_PAX;
+}
 
 /** @brief Number of GT/s capable for each PCI generation or \p link_rate */
 static const float switchtec_gen_transfers[] = {0, 2.5, 5, 8, 16};

--- a/inc/switchtec/switchtec.h
+++ b/inc/switchtec/switchtec.h
@@ -386,6 +386,35 @@ static inline int switchtec_is_pax(struct switchtec_dev *dev)
 	return switchtec_variant(dev) == SWITCHTEC_PAX;
 }
 
+/**
+ * @brief Return the generation string of a Switchtec device.
+ */
+static inline const char *switchtec_gen_str(struct switchtec_dev *dev)
+{
+	const char *str;
+
+	str =  switchtec_is_gen3(dev) ? "GEN3" :
+	       switchtec_is_gen4(dev) ? "GEN4" : "Unknown";
+
+	return str;
+}
+
+/**
+ * @brief Return the variant string of a Switchtec device.
+ */
+static inline const char *switchtec_variant_str(struct switchtec_dev *dev)
+{
+	const char *str;
+
+	str = switchtec_is_pfx(dev) ? "PFX" :
+	      switchtec_is_pfxl(dev) ? "PFX-L" :
+	      switchtec_is_pfxi(dev) ? "PFX-I" :
+	      switchtec_is_psx(dev) ? "PSX" :
+	      switchtec_is_pax(dev) ? "PAX" : "Unknown";
+
+	return str;
+}
+
 /** @brief Number of GT/s capable for each PCI generation or \p link_rate */
 static const float switchtec_gen_transfers[] = {0, 2.5, 5, 8, 16};
 /** @brief Number of GB/s capable for each PCI generation or \p link_rate */

--- a/lib/platform/gasops.c
+++ b/lib/platform/gasops.c
@@ -102,6 +102,11 @@ int gasop_cmd(struct switchtec_dev *dev, uint32_t cmd,
 	return ret;
 }
 
+int gasop_get_device_id(struct switchtec_dev *dev)
+{
+	return gas_reg_read32(dev, sys_info.device_id);
+}
+
 int gasop_get_fw_version(struct switchtec_dev *dev, char *buf,
 			 size_t buflen)
 {

--- a/lib/platform/gasops.h
+++ b/lib/platform/gasops.h
@@ -32,6 +32,7 @@ void gasop_set_partition_info(struct switchtec_dev *dev);
 int gasop_cmd(struct switchtec_dev *dev, uint32_t cmd,
 	      const void *payload, size_t payload_len, void *resp,
 	      size_t resp_len);
+int gasop_get_device_id(struct switchtec_dev *dev);
 int gasop_get_fw_version(struct switchtec_dev *dev, char *buf,
 			 size_t buflen);
 int gasop_pff_to_port(struct switchtec_dev *dev, int pff,

--- a/lib/platform/linux-i2c.c
+++ b/lib/platform/linux-i2c.c
@@ -581,6 +581,7 @@ static const struct switchtec_ops i2c_ops = {
 	.gas_map = i2c_gas_map,
 
 	.cmd = gasop_cmd,
+	.get_device_id = gasop_get_device_id,
 	.get_fw_version = gasop_get_fw_version,
 	.pff_to_port = gasop_pff_to_port,
 	.port_to_pff = gasop_port_to_pff,

--- a/lib/platform/linux-uart.c
+++ b/lib/platform/linux-uart.c
@@ -435,6 +435,7 @@ static const struct switchtec_ops uart_ops = {
 	.gas_map = uart_gas_map,
 
 	.cmd = gasop_cmd,
+	.get_device_id = gasop_get_device_id,
 	.get_fw_version = gasop_get_fw_version,
 	.pff_to_port = gasop_pff_to_port,
 	.port_to_pff = gasop_port_to_pff,

--- a/lib/platform/linux.c
+++ b/lib/platform/linux.c
@@ -265,6 +265,16 @@ int switchtec_list(struct switchtec_device_info **devlist)
 	return n;
 }
 
+static int linux_get_device_id(struct switchtec_dev *dev)
+{
+	char link_path[PATH_MAX];
+
+	snprintf(link_path, sizeof(link_path), "%s/%s/device/device",
+		 sys_path, basename(dev->name));
+
+	return sysfs_read_int(link_path, 16);
+}
+
 static int linux_get_fw_version(struct switchtec_dev *dev, char *buf,
 				size_t buflen)
 {
@@ -943,6 +953,7 @@ static int linux_event_wait(struct switchtec_dev *dev, int timeout_ms)
 
 static const struct switchtec_ops linux_ops = {
 	.close = linux_close,
+	.get_device_id = linux_get_device_id,
 	.get_fw_version = linux_get_fw_version,
 	.cmd = linux_cmd,
 	.get_devices = linux_get_devices,

--- a/lib/platform/windows.c
+++ b/lib/platform/windows.c
@@ -428,6 +428,7 @@ static const struct switchtec_ops windows_ops = {
 	.gas_map = windows_gas_map,
 	.event_wait = windows_event_wait,
 
+	.get_device_id = gasop_get_device_id,
 	.get_fw_version = gasop_get_fw_version,
 	.pff_to_port = gasop_pff_to_port,
 	.port_to_pff = gasop_port_to_pff,

--- a/lib/switchtec.c
+++ b/lib/switchtec.c
@@ -56,6 +56,98 @@
  */
 
 /**
+ * @brief Switchtec device id to generation/variant mapping
+ */
+struct switchtec_device_id {
+	unsigned short device_id;
+	enum switchtec_gen gen;
+	enum switchtec_variant var;
+};
+
+/**
+ * @brief Supported Switchtec device id table
+ */
+const struct switchtec_device_id switchtec_device_id_tbl[] = {
+	{0x8531, SWITCHTEC_GEN3, SWITCHTEC_PFX},   //PFX 24xG3
+	{0x8532, SWITCHTEC_GEN3, SWITCHTEC_PFX},   //PFX 32xG3
+	{0x8533, SWITCHTEC_GEN3, SWITCHTEC_PFX},   //PFX 48xG3
+	{0x8534, SWITCHTEC_GEN3, SWITCHTEC_PFX},   //PFX 64xG3
+	{0x8535, SWITCHTEC_GEN3, SWITCHTEC_PFX},   //PFX 80xG3
+	{0x8536, SWITCHTEC_GEN3, SWITCHTEC_PFX},   //PFX 96xG3
+	{0x8541, SWITCHTEC_GEN3, SWITCHTEC_PSX},   //PSX 24xG3
+	{0x8542, SWITCHTEC_GEN3, SWITCHTEC_PSX},   //PSX 32xG3
+	{0x8543, SWITCHTEC_GEN3, SWITCHTEC_PSX},   //PSX 48xG3
+	{0x8544, SWITCHTEC_GEN3, SWITCHTEC_PSX},   //PSX 64xG3
+	{0x8545, SWITCHTEC_GEN3, SWITCHTEC_PSX},   //PSX 80xG3
+	{0x8546, SWITCHTEC_GEN3, SWITCHTEC_PSX},   //PSX 96xG3
+	{0x8551, SWITCHTEC_GEN3, SWITCHTEC_PAX},   //PAX 24XG3
+	{0x8552, SWITCHTEC_GEN3, SWITCHTEC_PAX},   //PAX 32XG3
+	{0x8553, SWITCHTEC_GEN3, SWITCHTEC_PAX},   //PAX 48XG3
+	{0x8554, SWITCHTEC_GEN3, SWITCHTEC_PAX},   //PAX 64XG3
+	{0x8555, SWITCHTEC_GEN3, SWITCHTEC_PAX},   //PAX 80XG3
+	{0x8556, SWITCHTEC_GEN3, SWITCHTEC_PAX},   //PAX 96XG3
+	{0x8561, SWITCHTEC_GEN3, SWITCHTEC_PFXL},  //PFXL 24XG3
+	{0x8562, SWITCHTEC_GEN3, SWITCHTEC_PFXL},  //PFXL 32XG3
+	{0x8563, SWITCHTEC_GEN3, SWITCHTEC_PFXL},  //PFXL 48XG3
+	{0x8564, SWITCHTEC_GEN3, SWITCHTEC_PFXL},  //PFXL 64XG3
+	{0x8565, SWITCHTEC_GEN3, SWITCHTEC_PFXL},  //PFXL 80XG3
+	{0x8566, SWITCHTEC_GEN3, SWITCHTEC_PFXL},  //PFXL 96XG3
+	{0x8571, SWITCHTEC_GEN3, SWITCHTEC_PFXI},  //PFXI 24XG3
+	{0x8572, SWITCHTEC_GEN3, SWITCHTEC_PFXI},  //PFXI 32XG3
+	{0x8573, SWITCHTEC_GEN3, SWITCHTEC_PFXI},  //PFXI 48XG3
+	{0x8574, SWITCHTEC_GEN3, SWITCHTEC_PFXI},  //PFXI 64XG3
+	{0x8575, SWITCHTEC_GEN3, SWITCHTEC_PFXI},  //PFXI 80XG3
+	{0x8576, SWITCHTEC_GEN3, SWITCHTEC_PFXI},  //PFXI 96XG3
+	{0x4000, SWITCHTEC_GEN4, SWITCHTEC_PFX},   //PFX 100XG4
+	{0x4084, SWITCHTEC_GEN4, SWITCHTEC_PFX},   //PFX 84XG4
+	{0x4068, SWITCHTEC_GEN4, SWITCHTEC_PFX},   //PFX 68XG4
+	{0x4052, SWITCHTEC_GEN4, SWITCHTEC_PFX},   //PFX 52XG4
+	{0x4036, SWITCHTEC_GEN4, SWITCHTEC_PFX},   //PFX 36XG4
+	{0x4028, SWITCHTEC_GEN4, SWITCHTEC_PFX},   //PFX 28XG4
+	{0x4100, SWITCHTEC_GEN4, SWITCHTEC_PSX},   //PSX 100XG4
+	{0x4184, SWITCHTEC_GEN4, SWITCHTEC_PSX},   //PSX 84XG4
+	{0x4168, SWITCHTEC_GEN4, SWITCHTEC_PSX},   //PSX 68XG4
+	{0x4152, SWITCHTEC_GEN4, SWITCHTEC_PSX},   //PSX 52XG4
+	{0x4136, SWITCHTEC_GEN4, SWITCHTEC_PSX},   //PSX 36XG4
+	{0x4128, SWITCHTEC_GEN4, SWITCHTEC_PSX},   //PSX 28XG4
+	{0x4200, SWITCHTEC_GEN4, SWITCHTEC_PAX},   //PAX 100XG4
+	{0x4284, SWITCHTEC_GEN4, SWITCHTEC_PAX},   //PAX 84XG4
+	{0x4268, SWITCHTEC_GEN4, SWITCHTEC_PAX},   //PAX 68XG4
+	{0x4252, SWITCHTEC_GEN4, SWITCHTEC_PAX},   //PAX 52XG4
+	{0x4236, SWITCHTEC_GEN4, SWITCHTEC_PAX},   //PAX 36XG4
+	{0x4228, SWITCHTEC_GEN4, SWITCHTEC_PAX},   //PAX 28XG4
+	{0},
+};
+
+static int set_gen_variant(struct switchtec_dev * dev)
+{
+	const struct switchtec_device_id *id = switchtec_device_id_tbl;
+
+	dev->device_id = dev->ops->get_device_id(dev);
+	if (dev->device_id < 0) {
+		errno = ENOTSUP;
+		return -1;
+	}
+
+	dev->gen = SWITCHTEC_GEN_UNKNOWN;
+	while (id->device_id) {
+		if (id->device_id == dev->device_id) {
+			dev->gen = id->gen;
+			dev->var = id->var;
+		}
+
+		id++;
+	}
+
+	if (dev->gen == SWITCHTEC_GEN_UNKNOWN) {
+		errno = ENOTSUP;
+		return -1;
+	}
+
+	return 0;
+}
+
+/**
  * @brief Open a Switchtec device by string
  * @param[in] device A string representing the device to open
  * @return A switchtec_dev structure for use in other library functions
@@ -133,7 +225,46 @@ found:
 	else
 		errno = ENODEV;
 
+	if (set_gen_variant(ret))
+		return NULL;
+
 	return ret;
+}
+
+/**
+ * @brief Get the device id of the device
+ * @param[in] dev Switchtec device handle
+ * @return The device id of the device
+ *
+ * This is only valid if the device was opend with switchtec_open().
+ */
+_PURE int switchtec_device_id(struct switchtec_dev *dev)
+{
+	return dev->device_id;
+}
+
+/**
+ * @brief Get the generation of the device
+ * @param[in] dev Switchtec device handle
+ * @return The generation of the device
+ *
+ * This is only valid if the device was opend with switchtec_open().
+ */
+_PURE enum switchtec_gen switchtec_gen(struct switchtec_dev *dev)
+{
+	return dev->gen;
+}
+
+/**
+ * @brief Get the variant type of the device
+ * @param[in] dev Switchtec device handle
+ * @return The variant type of the device
+ *
+ * This is only valid if the device was opend with switchtec_open().
+ */
+_PURE enum switchtec_variant switchtec_variant(struct switchtec_dev *dev)
+{
+	return dev->var;
 }
 
 /**

--- a/lib/switchtec_priv.h
+++ b/lib/switchtec_priv.h
@@ -36,6 +36,7 @@ struct switchtec_dev;
 
 struct switchtec_ops {
 	void (*close)(struct switchtec_dev *dev);
+	int (*get_device_id)(struct switchtec_dev *dev);
 	int (*get_fw_version)(struct switchtec_dev *dev, char *buf,
 			      size_t buflen);
 	int (*cmd)(struct switchtec_dev *dev,  uint32_t cmd,

--- a/lib/switchtec_priv.h
+++ b/lib/switchtec_priv.h
@@ -90,6 +90,9 @@ struct switchtec_ops {
 };
 
 struct switchtec_dev {
+	int device_id;
+	enum switchtec_gen gen;
+	enum switchtec_variant var;
 	int partition, partition_count;
 	char name[PATH_MAX];
 


### PR DESCRIPTION
1, add get_device_id() instances for all interfaces
2, minor update to patch 'Add global pax id handling functions for CLI' to give error message if cannot set pax id.
3, assign proper errno in set_gen_variant()